### PR TITLE
Blinding fast solving for catchup state

### DIFF
--- a/scripts/cubelets.js
+++ b/scripts/cubelets.js
@@ -898,7 +898,7 @@ setupTasks.push( function(){
 
 			var 
 			twistDuration = this.cube !== undefined ? this.cube.twistDuration : SECOND,
-			twistDurationScaled = [ degrees.absolute().scale( 0, 90, 0, twistDuration ), 250 ].maximum()
+			twistDurationScaled = [ degrees.absolute().scale( 0, 90, 0, twistDuration ), 0 ].maximum()
 
 
 			//  And now for the rotation tween itself...

--- a/scripts/solvers/clock.js
+++ b/scripts/solvers/clock.js
@@ -165,7 +165,7 @@ solver.logic = function( cube ){
 
     if (newClockData || Math.abs(minutesSinceMidnight - clockIndex) > 10) {
         catchUp = true
-        cube.twistDuration = SECOND / 4
+        cube.twistDuration = 0
         if (catchupBlackAndWhite) {
             showCatchup(cube)
         }


### PR DESCRIPTION
When the clock initializes or if the browser wakes from sleep the cube now does that initial solve sequence very quickly thus arriving at the arrive at the current time with negligible delay.