### PR TITLE
Show current time of day in install script

### DIFF
--- a/pi-init/install.sh
+++ b/pi-init/install.sh
@@ -71,13 +71,24 @@ echo "cube splash screen on boot = $installsplash"
 echo "cube desktop               = $installwallpaper"
 echo "hide trashcan icon         = $hidetrash"
 echo "hide sdcard mounts icons   = $hidemounts"
-timedatectl show | grep Timezone
 echo
+timedatectl show | grep Timezone
+
+
 
 if [ "$clockstyle" != 12 ] && [ "$clockstyle" != 24 ]; then
     echo "Illegal value --style must be either 12 or 24"
     exit 1
 fi
+
+echo -n "Current time: "
+if [ "$clockstyle" == 24 ] ; then
+    date +"%R"
+else
+    date +"%r"
+fi
+
+echo
 
 while true; do
     read -p "Is configuration good? [Y or N] " yn


### PR DESCRIPTION
before user commits to settings, show the current time of day and time zone of the Raspberry pi allowing them to cancel install if that is not correct.
If user selected 12-hour clock then time of day is printed her as am/pm
If user selected 24-hour clock then time is printed in 24-hour format.
