### PR TITLE
Better defaults based on user's local and defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
 
 		<!--  Here are the Cube guts. Enjoy.  -->
 
+		<script charset="utf-8" src="scripts/defaults12.js"></script>
+		<script charset="utf-8" src="scripts/userdefaults.js"></script> <!-- It's ok if this file is missing -->
+		
 		<script charset="utf-8" src="scripts/colors.js"></script>
 		<script charset="utf-8" src="scripts/directions.js"></script>
 		<script charset="utf-8" src="scripts/queues.js"></script>

--- a/pi-init/install.sh
+++ b/pi-init/install.sh
@@ -183,6 +183,12 @@ else
     rm -f /home/pi/.config/autostart/rubiks-clock.desktop 
 fi
 
+if [ "$clockstyle" == '24' ]; then
+    cp $SCRIPT_DIR/../scripts/defaults24.js $SCRIPT_DIR/../scripts/userdefaults.js
+else
+    cp $SCRIPT_DIR/../scripts/defaults12.js $SCRIPT_DIR/../scripts/userdefaults.js
+fi
+
 #echo
 #echo 'If you want to hide the cursor, run this command:'
 #echo 'echo point_at_menu=0 >> /home/pi/.config/lxpanel/LXDE-pi/panels/panel'

--- a/scripts/cubes.js
+++ b/scripts/cubes.js
@@ -129,7 +129,7 @@ function Cube( preset ){
 	this.zoomSizeBig = 1200
 	this.zoomSizeGiant = 900
 
-	this.defaultClockIs24 = false  // set to true if you want 24-hour clock as default preset
+	this.defaultClockIs24 = defaultClockIs24  || false // from defaults.js set to true if you want 24-hour clock as default preset
 
 	//  Size matters? Cubelets will attempt to read these values.
 	this.size = 420
@@ -1098,8 +1098,8 @@ setupTasks.push( function(){
 
 			var cube = this
 			
-			xAngle = this.rotationAngleX || 25
-			yAngle = this.rotationAngleY || -30
+			xAngle = this.rotationAngleX || rotationAngleX || 25
+			yAngle = this.rotationAngleY || rotationAngleY || -30
 
 			this.threeObject.position.y = -2000
 			new TWEEN.Tween( this.threeObject.position )
@@ -1308,6 +1308,15 @@ setupTasks.push( function(){
 			
 			}, 1 )
 		},
+		zoomInFromFar: function (){
+			this.threeObject.position.y = 2000
+			new TWEEN.Tween( this.threeObject.position )
+				.to({ 
+					y: 0
+				}, SECOND * 2 )
+				.easing( TWEEN.Easing.Quartic.Out )
+				.start()
+		},
 		clockInit: function(){
 			//$("#favicon").attr("href","media/rubiks-clock-favicon.png")
 			// TODO set title to "Rubik's Clock"
@@ -1382,8 +1391,8 @@ setupTasks.push( function(){
 			this.zoom = this.zoomSizeGiant
 			
 			// It will fit on thee screen better if not rotated so much
-			this.rotationAngleX = 17
-			this.rotationAngleY = -17
+			//this.rotationAngleX = 17
+			//this.rotationAngleY = -17
 
 			this.presetClock12()
 		},
@@ -1448,8 +1457,8 @@ setupTasks.push( function(){
 		presetGiantclock24: function(){
 			this.zoom = this.zoomSizeGiant
 			// It will fit on thee screen better if not rotated so much
-			this.rotationAngleX = 17
-			this.rotationAngleY = -17
+			//this.rotationAngleX = 17
+			//this.rotationAngleY = -17
 
 			this.presetClock24()
 		},
@@ -1479,7 +1488,7 @@ setupTasks.push( function(){
 		presetExperiments(){
 
 
-			this.clockType = 12
+			this.clockType = 24
 
 			setCameraZoom(this.zoom)
 			//this.rotationAngleX = 15
@@ -1573,11 +1582,11 @@ setupTasks.push( function(){
 				return moves
 			}
 
-			hours1   = 12+6
-			minutes1 = 23
+			hours1   = 12+2
+			minutes1 = 20
 
-			hours2   = 12+6
-			minutes2 = 24
+			hours2   = 12+2
+			minutes2 = 21
 
 			this.taskQueue.add(
 

--- a/scripts/defaults12.js
+++ b/scripts/defaults12.js
@@ -1,0 +1,14 @@
+
+
+//set to true if you want 24-hour clock as default preset
+defaultClockIs24 = false
+
+zoomSizeDefault = 1500
+
+// minimal angle mostly shows the front of the cube
+rotationAngleX = 17
+rotationAngleY = -17
+
+// uncomment to show more of the cube
+//rotationAngleX = 25
+//rotationAngleY = -30

--- a/scripts/defaults24.js
+++ b/scripts/defaults24.js
@@ -1,0 +1,12 @@
+
+
+//set to true if you want 24-hour clock as default preset
+defaultClockIs24 = true
+
+// minimal angle mostly shows the front of the cube
+rotationAngleX = 17
+rotationAngleY = -17
+
+// uncomment to show more of the cube
+//rotationAngleX = 25
+//rotationAngleY = -30

--- a/scripts/solvers/clock.js
+++ b/scripts/solvers/clock.js
@@ -27,7 +27,7 @@ catchUp = false
 lightningCatchup = false
 
 // normally we just hide the cube but set this to true to show a black&white version while it solves
-catchupBlackAndWhite = false
+catchupBlackAndWhite = true
 
 clockType = null
 clockDataPrevious = null


### PR DESCRIPTION
index.html includes usrdefaults.js which will only exist if the user ran the install.sh script.  The install script configures based on user selection of 12-hour clock or 24-hour clock.
If usrdefaults.js does not exist then default values come from defaults12.js

I also enabled the wire frame b/w display for when the browser wakes and needs to catch up.
The screen is no longer blank for 5 or so seconds.